### PR TITLE
集会サムネイルコンポーネントの実装

### DIFF
--- a/src/components/MeetingThumbnail/MeetingThumbnail.vue
+++ b/src/components/MeetingThumbnail/MeetingThumbnail.vue
@@ -37,7 +37,6 @@ defineProps<{ meeting: Meeting }>()
 }
 
 .title {
-  font-size: 0.9375rem;
   font-weight: bold;
   display: -webkit-box;
   -webkit-box-orient: vertical;
@@ -46,7 +45,7 @@ defineProps<{ meeting: Meeting }>()
 }
 
 .description {
-  font-size: 0.8125rem;
+  font-size: 0.75rem;
   display: -webkit-box;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 3;

--- a/src/components/MeetingThumbnail/MeetingThumbnail.vue
+++ b/src/components/MeetingThumbnail/MeetingThumbnail.vue
@@ -1,0 +1,55 @@
+<script setup lang="ts">
+import { Meeting } from '@/lib/apis'
+
+defineProps<{ meeting: Meeting }>()
+</script>
+
+<template>
+  <router-link
+    :to="{ name: 'Meeting', params: { id: meeting.id } }"
+    :class="$style.container"
+  >
+    <!-- TODO: 日付コンポーネントを表示する -->
+    <img :src="meeting.thumbnail" :alt="`${meeting.title}のサムネイル画像`" />
+    <div :class="$style.textContainer">
+      <div :class="$style.title">{{ meeting.title }}</div>
+      <div :class="$style.description">{{ meeting.description }}</div>
+    </div>
+  </router-link>
+</template>
+
+<style lang="scss" module>
+.container {
+  width: 16.625rem;
+  display: flex;
+  flex-direction: column;
+  background-color: white;
+  color: black;
+  text-decoration: none;
+}
+
+.textContainer {
+  height: 8rem;
+  padding: 0.5rem 0.625rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.title {
+  font-size: 0.9375rem;
+  font-weight: bold;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
+}
+
+.description {
+  font-size: 0.8125rem;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  overflow: hidden;
+}
+</style>

--- a/src/components/MeetingThumbnail/MeetingThumbnail.vue
+++ b/src/components/MeetingThumbnail/MeetingThumbnail.vue
@@ -12,8 +12,8 @@ defineProps<{ meeting: Meeting }>()
     <!-- TODO: 日付コンポーネントを表示する -->
     <img :src="meeting.thumbnail" :alt="`${meeting.title}のサムネイル画像`" />
     <div :class="$style.textContainer">
-      <div :class="$style.title">{{ meeting.title }}</div>
-      <div :class="$style.description">{{ meeting.description }}</div>
+      <p :class="$style.title">{{ meeting.title }}</p>
+      <p :class="$style.description">{{ meeting.description }}</p>
     </div>
   </router-link>
 </template>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -5,6 +5,12 @@ const routes: RouteRecordRaw[] = [
     path: '/',
     name: 'Index',
     component: () => import('@/pages/Index.vue')
+  },
+  {
+    path: '/meeting/:id',
+    name: 'Meeting',
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    component: () => {} // TODO: ページ作成したらここに書く
   }
 ]
 


### PR DESCRIPTION
close #13 

- サムネイルをクリックしたら集会のページに飛びたいので、遷移先のpathだけ用意しました
- 日付表示だけまだです

`@/pages/index.vue`を以下のようにしてデバッグできます
```vue
<script setup lang="ts">
import { reactive } from 'vue'
import { Meeting } from '@/lib/apis'
import MeetingThumbnail from '@/components/MeetingThumbnail/MeetingThumbnail.vue'

const m = reactive<Meeting>({
  id: 'hoge',
  title:
    '長めのタイトル長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い',
  description:
    '長めの説明長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い長い',
  thumbnail:
    'https://i.ytimg.com/vi/lMEt3RdqB9Y/hq720.jpg?sqp=-oaymwEcCNAFEJQDSFXyq4qpAw4IARUAAIhCGAFwAcABBg==&rs=AOn4CLCzfCHH_ecPXfsWt8DAud71QpvkbQ',
  started_at: '',
  ended_at: '',
  video_id: ''
})
</script>

<template>
  <meeting-thumbnail :meeting="m" />
  <meeting-thumbnail :meeting="{ ...m, title: 'a', description: 'a' }" />
</template>

```